### PR TITLE
Fix a panic on exit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         move || {
             let mut buf = [0; 5];
             loop {
-                stream.read_exact(&mut buf).unwrap();
+                let _ = stream.read_exact(&mut buf);
                 if should_exit.load(Ordering::SeqCst) {
                     break;
                 }
@@ -151,7 +151,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     reader
         .read_async(args.buffers, 0, |bytes| {
             buf_write_stream.write_all(bytes).unwrap_or_else(|_err| {
-                sender.try_send(()).expect("can't exit normally");
+                let _ = sender.try_send(());
             });
         })
         .unwrap();


### PR DESCRIPTION
This was breaking the systemd service for me.

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/niclashoyer/rtltcp/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/niclashoyer/rtltcp/blob/main/CHANGELOG.md
-->
